### PR TITLE
Add cdap provider to dataproc_profile module versions

### DIFF
--- a/modules/dataproc_profile/versions.tf
+++ b/modules/dataproc_profile/versions.tf
@@ -22,6 +22,11 @@ terraform {
       source  = "hashicorp/google"
       version = ">= 3.53, < 5.0"
     }
+
+    cdap = {
+      source  = "GoogleCloudPlatform/cdap"
+      version = ">= 0.1.0"
+    }
   }
 
   provider_meta "google" {


### PR DESCRIPTION
Fixes https://github.com/terraform-google-modules/terraform-google-data-fusion/issues/47 and https://github.com/GoogleCloudPlatform/terraform-provider-cdap/issues/101